### PR TITLE
Исправлены пути до картинок в Minio

### DIFF
--- a/internal/applications/initiator/app.go
+++ b/internal/applications/initiator/app.go
@@ -54,7 +54,7 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 			logger.Fatal("run minio client: ", zap.Error(err))
 		}
 	}
-	appBenchesStorage := storage.NewMinioStorage(minioClient, cfg.Minio.Bucket, "")
+	appBenchesStorage := storage.NewMinioStorage(minioClient, cfg.Minio.Bucket, cfg.Images.PublicEndpoint)
 	appBenchesRepository := postgres.NewBenchesRepository(db)
 	appBenchesService := benchesService.NewService(appBenchesRepository, appBenchesStorage, logger)
 	appHandlerBenches := benches.NewBenchesHandler(appBenchesService)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 		Bucket    string `env:"MINIO_BUCKET" env-default:"benches"`
 		UseSSL    bool   `env:"MINIO_USE_SSL" env-default:"true"`
 	}
+	Images struct {
+		PublicEndpoint string `env:"IMAGES_PUBLIC_ENDPOINT" env-default:"http://localhost:9000"`
+	}
 }
 
 var instance *Config

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -26,6 +26,9 @@ func (s *Service) GetListBenches(ctx context.Context) ([]domain.Bench, error) {
 		s.log.Error("error get all benches", zap.Error(err))
 		return nil, err
 	}
+	for idx := range users {
+		users[idx].Image = s.storage.GetImageURL(users[idx].Image)
+	}
 	return users, nil
 }
 


### PR DESCRIPTION
Были исправлены пути до картинок.

Ранее:
`benches/01GDX8HNPJPZ4N49KV0MGR05YK.jpg`

Сейчас:
`https://localhost:9000/benches/01GDX8HNPJPZ4N49KV0MGR05YK.jpg`

Для этого была добавлена структура `Images` в конфигурацию. 