### PR TITLE
Исправлена авторизацию через Telegram. Добавлена проверка на пустое поле.

### DIFF
--- a/pkg/telegram/manager.go
+++ b/pkg/telegram/manager.go
@@ -26,7 +26,7 @@ func (m *Manager) CheckTelegramAuthorization(params map[string]string) bool {
 
 	var checkParams []string
 	for k, v := range params {
-		if k != "hash" {
+		if k != "hash" && len(v) != 0 {
 			checkParams = append(checkParams, fmt.Sprintf("%s=%s", k, v))
 		}
 	}


### PR DESCRIPTION
Ранее если у пользователя не было `last_name`, то авторизация не проходила, так как `last_name` в `params` был `""`. 

Согласно документации telegram, если поле пустое, то его не должно быть в конечной строке. Добавлена проверка на то, что поле не пустое.