### PR TITLE
Исправлено подключение к Redis

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,11 +31,16 @@ services:
 
   redis:
     image: bitnami/redis:7.0.5
+    command:
+      - /bin/sh
+      - -c
+      - redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"
     container_name: benches-redis
     volumes:
       - redis_data:/bitnami/redis/data
     ports:
       - "6379:6379"
+    env_file: .env
 
   minio:
     image: minio/minio:latest


### PR DESCRIPTION
Добавлен параметр `env_file: .env`, также добавлена команда для обязательного запроса пароля при подключении к Redis.

См. https://stackoverflow.com/questions/68461172/docker-compose-redis-password-via-environment-variable