### PR TITLE
Добавлены минимальные уведомления в Telegram и handling error

### DIFF
--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -1,0 +1,39 @@
+package apperror
+
+import "encoding/json"
+
+var (
+	ErrNotFound           = NewAppError(nil, "not found")
+	ErrIncorrectDataAuth  = NewAppError(nil, "incorrect login details")
+	ErrIncorrectDataToken = NewAppError(nil, "incorrect token")
+)
+
+type AppError struct {
+	Err     error  `json:"-"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e *AppError) Error() string {
+	return e.Message
+}
+
+func (e *AppError) Unwrap() error { return e.Err }
+
+func (e *AppError) Marshal() []byte {
+	marshal, err := json.Marshal(e)
+	if err != nil {
+		return nil
+	}
+	return marshal
+}
+
+func NewAppError(err error, message string) *AppError {
+	return &AppError{
+		Err:     err,
+		Message: message,
+	}
+}
+
+func systemError(err error) *AppError {
+	return NewAppError(err, "internal system error")
+}

--- a/internal/apperror/middleware.go
+++ b/internal/apperror/middleware.go
@@ -1,0 +1,43 @@
+package apperror
+
+import (
+	"errors"
+	"net/http"
+)
+
+type appHandler func(w http.ResponseWriter, r *http.Request) error
+
+func Middleware(h appHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var appErr *AppError
+		err := h(w, r)
+		if err != nil {
+			if errors.As(err, &appErr) {
+				if errors.Is(err, ErrNotFound) {
+					w.WriteHeader(http.StatusNotFound)
+					w.Write(ErrNotFound.Marshal())
+					return
+				}
+				if errors.Is(err, ErrIncorrectDataAuth) {
+					w.WriteHeader(http.StatusNotFound)
+					w.Write(ErrIncorrectDataAuth.Marshal())
+					return
+				}
+				if errors.Is(err, ErrIncorrectDataToken) {
+					w.WriteHeader(http.StatusNotFound)
+					w.Write(ErrIncorrectDataToken.Marshal())
+					return
+				}
+				err = err.(*AppError)
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write(appErr.Marshal())
+				return
+			}
+
+			w.WriteHeader(http.StatusTeapot)
+			w.Write(systemError(err).Marshal())
+		}
+	}
+}

--- a/internal/applications/initiator/app.go
+++ b/internal/applications/initiator/app.go
@@ -7,6 +7,7 @@ import (
 	"benches/internal/handlers/users"
 	"benches/internal/repository/postgres"
 	benchesService "benches/internal/service/benches"
+	notificationsSerivce "benches/internal/service/notifications"
 	usersService "benches/internal/service/users"
 	minioStorage "benches/internal/storage/minio"
 	redisStorage "benches/internal/storage/redis"
@@ -78,10 +79,12 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 		logger.Fatal("init auth manager: ", zap.Error(err))
 	}
 
+	appNotificationsService := notificationsSerivce.NewService(logger, "http://localhost:8080/api/v1/notification")
+
 	appBenchesRouter := router.PathPrefix("/api/v1/benches").Subrouter()
 	appBenchesStorage := minioStorage.NewMinioStorage(minioClient, cfg.Minio.Bucket, cfg.Images.PublicEndpoint)
 	appBenchesRepository := postgres.NewBenchesRepository(db)
-	appBenchesService := benchesService.NewService(appBenchesRepository, appBenchesStorage, logger)
+	appBenchesService := benchesService.NewService(appBenchesRepository, appBenchesStorage, logger, appNotificationsService)
 	appHandlerBenches := benches.NewBenchesHandler(appBenchesService)
 	appHandlerBenches.Register(appBenchesRouter, authManager)
 

--- a/internal/handlers/users/users.go
+++ b/internal/handlers/users/users.go
@@ -1,8 +1,10 @@
 package users
 
 import (
+	"benches/internal/apperror"
 	"benches/internal/dto"
 	"encoding/json"
+	"fmt"
 	"github.com/gorilla/mux"
 	"net/http"
 )
@@ -17,8 +19,8 @@ func NewUsersHandler(users Service) *Handler {
 }
 
 func (h *Handler) Register(router *mux.Router) {
-	router.HandleFunc("/api/v1/users", h.registerUser)
-	router.HandleFunc("/api/v1/users/refresh", h.refreshToken)
+	router.HandleFunc("/api/v1/users", apperror.Middleware(h.registerUser))
+	router.HandleFunc("/api/v1/users/refresh", apperror.Middleware(h.refreshToken))
 }
 
 // RegisterUser
@@ -29,18 +31,19 @@ func (h *Handler) Register(router *mux.Router) {
 // @Success 200
 // @Failure 400
 // @Router /api/v1/users [post]
-func (h *Handler) registerUser(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) registerUser(w http.ResponseWriter, r *http.Request) error {
 	var user dto.CreateUser
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		fmt.Println(err)
+		return apperror.ErrIncorrectDataAuth
 	}
 	token, refreshToken, err := h.users.LoginViaTelegram(r.Context(), user)
 	if err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		fmt.Println(err)
+		return apperror.ErrIncorrectDataAuth
 	}
 	h.ResponseJson(w, map[string]string{"access": token, "refresh": refreshToken}, 200)
+	return nil
 }
 
 // RefreshToken
@@ -52,16 +55,17 @@ func (h *Handler) registerUser(w http.ResponseWriter, r *http.Request) {
 // @Success 200
 // @Failure 400
 // @Router /api/v1/users/refresh [post]
-func (h *Handler) refreshToken(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) refreshToken(w http.ResponseWriter, r *http.Request) error {
 	var token dto.RefreshToken
 	if err := json.NewDecoder(r.Body).Decode(&token); err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		fmt.Println(err)
+		return apperror.ErrIncorrectDataToken
 	}
 	accessToken, refreshToken, err := h.users.RefreshToken(r.Context(), token.Token)
 	if err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		fmt.Println(err)
+		return apperror.ErrIncorrectDataToken
 	}
 	h.ResponseJson(w, map[string]string{"access": accessToken, "refresh": refreshToken}, 200)
+	return nil
 }

--- a/internal/repository/postgres/benches.go
+++ b/internal/repository/postgres/benches.go
@@ -13,7 +13,7 @@ type benchModel struct {
 	Lng      float64    `bun:"lng"`
 	Image    string     `bun:"image"`
 	IsActive bool       `bun:"is_active"`
-	Owner    *userModel `bun:"owner_id,rel:has-one,join:owner_id=id"`
+	Owner    *userModel `bun:"owner_id,rel:belongs-to,join=owner_id=id"`
 }
 
 func (b *benchModel) FromDomain(bench domain.Bench) {

--- a/internal/repository/postgres/benches_repository.go
+++ b/internal/repository/postgres/benches_repository.go
@@ -58,7 +58,7 @@ func (b *BenchesRepository) DeleteBench(ctx context.Context, id string) error {
 
 func (b *BenchesRepository) GetBenchByID(ctx context.Context, id string) (domain.Bench, error) {
 	model := benchModel{}
-	err := b.db.NewSelect().Model(&model).Where("id = ?", id).Scan(ctx)
+	err := b.db.NewSelect().Model(&model).Where("benches.id = ?", id).Relation("Owner").Scan(ctx)
 	if err != nil {
 		return domain.Bench{}, err
 	}

--- a/internal/service/notifications/notifications.go
+++ b/internal/service/notifications/notifications.go
@@ -1,0 +1,30 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type Service struct {
+	log                     *zap.Logger
+	telegramNotificationURL string
+}
+
+func NewService(log *zap.Logger, telegramNotificationURL string) *Service {
+	return &Service{
+		log:                     log,
+		telegramNotificationURL: telegramNotificationURL,
+	}
+}
+
+func (s *Service) SendNotificationInTelegram(ctx context.Context, typeNotification string, userID int) {
+	data := struct {
+		UserID int    `json:"user_id"`
+		Type   string `json:"type"`
+	}{UserID: 811495961, Type: "create_bench"}
+	jsonBody, _ := json.Marshal(data)
+	http.Post(s.telegramNotificationURL, "application/json", bytes.NewBuffer(jsonBody))
+}


### PR DESCRIPTION
Добавлен новый сервис `notifications`, добавлена обработка ошибок с помощью `apperror`. 

Теперь handler'ы возвращают ошибки, их ловит middleware и отдаёт в типизированном виде. 

Нужно добавить типизацию уведомлений и обновить `env.example`.