### PR TITLE
Добавлен mock для NotificationService, обновлено поле Role у пользователя

### DIFF
--- a/internal/applications/initiator/app.go
+++ b/internal/applications/initiator/app.go
@@ -7,7 +7,7 @@ import (
 	"benches/internal/handlers/users"
 	"benches/internal/repository/postgres"
 	benchesService "benches/internal/service/benches"
-	notificationsSerivce "benches/internal/service/notifications"
+	notificationsService "benches/internal/service/notifications"
 	usersService "benches/internal/service/users"
 	minioStorage "benches/internal/storage/minio"
 	redisStorage "benches/internal/storage/redis"
@@ -79,7 +79,12 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 		logger.Fatal("init auth manager: ", zap.Error(err))
 	}
 
-	appNotificationsService := notificationsSerivce.NewService(logger, cfg.Telegram.NotificationToken)
+	var appNotificationsService benchesService.NotificationService
+	if cfg.IsDevelopment {
+		appNotificationsService = notificationsService.NewServiceMock(logger, cfg.Telegram.NotificationToken)
+	} else {
+		appNotificationsService = notificationsService.NewService(logger, cfg.Telegram.NotificationToken)
+	}
 
 	appUsersRedisStorage := redisStorage.NewRedisStorage(redisClient)
 	appUsersTelegramManager := telegram.NewTelegramManager(cfg.Telegram.Token)

--- a/internal/repository/postgres/users.go
+++ b/internal/repository/postgres/users.go
@@ -11,7 +11,7 @@ type userModel struct {
 	ID         string `bun:"id,pk"`
 	Username   string `bun:"username"`
 	TelegramID int    `bun:"telegram_id"`
-	Role       string `bun:"role"`
+	Role       string `bun:"role,nullzero,notnull,default:'user'"`
 }
 
 func (u *userModel) FromDomain(user domain.User) {

--- a/internal/service/benches/interfaces.go
+++ b/internal/service/benches/interfaces.go
@@ -12,3 +12,7 @@ type Database interface {
 	DeleteBench(ctx context.Context, id string) error
 	GetBenchByID(ctx context.Context, id string) (domain.Bench, error)
 }
+
+type NotificationService interface {
+	SendNotificationInTelegram(ctx context.Context, decision string, id int, id2 string)
+}

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -4,7 +4,6 @@ import (
 	"benches/internal/domain"
 	"benches/internal/dto"
 	"benches/internal/repository/postgres"
-	"benches/internal/service/notifications"
 	storage "benches/internal/storage/minio"
 	"context"
 	"fmt"
@@ -16,12 +15,12 @@ type Service struct {
 	db                   Database
 	log                  *zap.Logger
 	storage              *storage.Storage
-	notificationsService *notifications.Service
+	notificationsService NotificationService
 	usersRepository      *postgres.UsersRepository
 }
 
 func NewService(db Database, storage *storage.Storage, log *zap.Logger,
-	notificationsService *notifications.Service, usersRepository *postgres.UsersRepository) *Service {
+	notificationsService NotificationService, usersRepository *postgres.UsersRepository) *Service {
 	return &Service{db: db, storage: storage, log: log, notificationsService: notificationsService,
 		usersRepository: usersRepository}
 }

--- a/internal/service/notifications/mock.go
+++ b/internal/service/notifications/mock.go
@@ -1,0 +1,23 @@
+package notifications
+
+import (
+	"context"
+	"go.uber.org/zap"
+)
+
+type ServiceMock struct {
+	log                     *zap.Logger
+	telegramNotificationURL string
+}
+
+func NewServiceMock(log *zap.Logger, telegramNotificationURL string) *ServiceMock {
+	return &ServiceMock{
+		log:                     log,
+		telegramNotificationURL: telegramNotificationURL,
+	}
+}
+
+func (s *ServiceMock) SendNotificationInTelegram(ctx context.Context, typeNotification string, userID int, benchID string) {
+	s.log.Info("Send message to telegram", zap.String("notification", typeNotification),
+		zap.Int("user", userID), zap.String("bench", benchID))
+}


### PR DESCRIPTION
Теперь, если `IS_DEV=True`, то уведомления не отправляются в telegram, а просто выводятся в консоль.
Добавлено: `notificationsService.ServiceMock`.

Также изменено поле `Role` у пользователя, теперь оно по умолчанию `user`.