### PR TITLE
Добавлено поле details в AppError

### DIFF
--- a/internal/domain/notifications.go
+++ b/internal/domain/notifications.go
@@ -1,0 +1,6 @@
+package domain
+
+type TelegramNotification struct {
+	UserID  int    `json:"user_id"`
+	Message string `json:"message"`
+}

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -87,6 +87,9 @@ func (s *service) DecisionBench(ctx context.Context, dto dto.DecisionBench) erro
 		return err
 	}
 
-	s.notificationsService.SendNotificationInTelegram(ctx, typeDecision, bench.Owner.TelegramID, bench.ID)
+	err = s.notificationsService.SendNotificationInTelegram(ctx, typeDecision, bench.Owner.TelegramID, bench.ID)
+	if err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
Было добавлено поле `details`, теперь AppError выглядит так:
```
type AppError struct {
	Err     error           `json:"-"`
	Message string          `json:"message,omitempty"`
	Details json.RawMessage `json:"details"`
}
```

Это сделано для того, чтобы можно было возвращать вложенный json. Например, ошибки о валидации отдельных полей.