### PR TITLE
Добавлена валидация некоторых DTO, добавлено новое поле в AppError, обновлён swagger для benches

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16,13 +16,39 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/v1/benches/": {
+            "get": {
+                "description": "Get list active benches",
+                "tags": [
+                    "Benches"
+                ],
+                "summary": "List benches",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Bench"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/benches/telegram": {
             "post": {
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "Benches"
+                    "Benches Moderation"
                 ],
                 "summary": "Create bench via telegram",
                 "parameters": [
@@ -115,6 +141,40 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "apperror.AppError": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Bench": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "lat": {
+                    "type": "number"
+                },
+                "lng": {
+                    "type": "number"
+                }
+            }
+        },
         "dto.CreateBenchViaTelegram": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,13 +4,39 @@
         "contact": {}
     },
     "paths": {
+        "/api/v1/benches/": {
+            "get": {
+                "description": "Get list active benches",
+                "tags": [
+                    "Benches"
+                ],
+                "summary": "List benches",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Bench"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.AppError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/benches/telegram": {
             "post": {
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "Benches"
+                    "Benches Moderation"
                 ],
                 "summary": "Create bench via telegram",
                 "parameters": [
@@ -103,6 +129,40 @@
         }
     },
     "definitions": {
+        "apperror.AppError": {
+            "type": "object",
+            "properties": {
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Bench": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "lat": {
+                    "type": "number"
+                },
+                "lng": {
+                    "type": "number"
+                }
+            }
+        },
         "dto.CreateBenchViaTelegram": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,26 @@
 definitions:
+  apperror.AppError:
+    properties:
+      details:
+        items:
+          type: integer
+        type: array
+      message:
+        type: string
+    type: object
+  domain.Bench:
+    properties:
+      id:
+        type: string
+      image:
+        type: string
+      is_active:
+        type: boolean
+      lat:
+        type: number
+      lng:
+        type: number
+    type: object
   dto.CreateBenchViaTelegram:
     properties:
       image:
@@ -37,6 +59,23 @@ definitions:
 info:
   contact: {}
 paths:
+  /api/v1/benches/:
+    get:
+      description: Get list active benches
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.Bench'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apperror.AppError'
+      summary: List benches
+      tags:
+      - Benches
   /api/v1/benches/telegram:
     post:
       parameters:
@@ -55,7 +94,7 @@ paths:
           description: Bad Request
       summary: Create bench via telegram
       tags:
-      - Benches
+      - Benches Moderation
   /api/v1/users:
     post:
       parameters:

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-redis/redis/v9 v9.0.0-beta.3 h1:rkIfHaVFD8vPPfA44MTKFtRlQ6I7K3xvQwKOu+Qnh94=
 github.com/go-redis/redis/v9 v9.0.0-beta.3/go.mod h1:XNkosunJlFQUw/sKdZ9rMyoRFgqk9SLUv2gbKTtvWl8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=

--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -3,14 +3,22 @@ package apperror
 import "encoding/json"
 
 var (
-	ErrNotFound           = NewAppError(nil, "not found")
-	ErrIncorrectDataAuth  = NewAppError(nil, "incorrect login details")
-	ErrIncorrectDataToken = NewAppError(nil, "incorrect token")
+	ErrNotFound           = NewAppError(nil, "not found", nil)
+	ErrIncorrectDataAuth  = NewAppError(nil, "incorrect login details", nil)
+	ErrIncorrectDataToken = NewAppError(nil, "incorrect token", nil)
+	ErrDecodeData         = NewAppError(nil, "error decode data", nil)
+	ErrNotEnoughRights    = NewAppError(nil, "not enough rights", nil)
 )
 
+type JSONMarshal interface {
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(data []byte) error
+}
+
 type AppError struct {
-	Err     error  `json:"-"`
-	Message string `json:"message,omitempty"`
+	Err     error           `json:"-"`
+	Message string          `json:"message,omitempty"`
+	Details json.RawMessage `json:"details"`
 }
 
 func (e *AppError) Error() string {
@@ -27,13 +35,14 @@ func (e *AppError) Marshal() []byte {
 	return marshal
 }
 
-func NewAppError(err error, message string) *AppError {
+func NewAppError(err error, message string, details json.RawMessage) *AppError {
 	return &AppError{
 		Err:     err,
 		Message: message,
+		Details: details,
 	}
 }
 
 func systemError(err error) *AppError {
-	return NewAppError(err, "internal system error")
+	return NewAppError(err, "internal system error", nil)
 }

--- a/internal/apperror/middleware.go
+++ b/internal/apperror/middleware.go
@@ -30,6 +30,16 @@ func Middleware(h appHandler) http.HandlerFunc {
 					w.Write(ErrIncorrectDataToken.Marshal())
 					return
 				}
+				if errors.Is(err, ErrDecodeData) {
+					w.WriteHeader(http.StatusNotFound)
+					w.Write(ErrDecodeData.Marshal())
+					return
+				}
+				if errors.Is(err, ErrNotEnoughRights) {
+					w.WriteHeader(http.StatusForbidden)
+					w.Write(ErrNotEnoughRights.Marshal())
+					return
+				}
 				err = err.(*AppError)
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write(appErr.Marshal())

--- a/internal/dto/benches.go
+++ b/internal/dto/benches.go
@@ -1,5 +1,7 @@
 package dto
 
+import validation "github.com/go-ozzo/ozzo-validation"
+
 type CreateBench struct {
 	Lat   float64 `json:"lat"`
 	Lng   float64 `json:"lng"`
@@ -16,4 +18,25 @@ type CreateBenchViaTelegram struct {
 type DecisionBench struct {
 	ID       string `json:"id"`
 	Decision bool   `json:"decision"`
+}
+
+func (bench *CreateBench) Validate() error {
+	return validation.ValidateStruct(bench,
+		validation.Field(&bench.Lat, validation.Required),
+		validation.Field(&bench.Lng, validation.Required),
+		validation.Field(&bench.Image, validation.Required))
+}
+
+func (bench *CreateBenchViaTelegram) Validate() error {
+	return validation.ValidateStruct(bench,
+		validation.Field(&bench.Lat, validation.Required),
+		validation.Field(&bench.Lng, validation.Required),
+		validation.Field(&bench.Image, validation.Required),
+		validation.Field(&bench.UserTelegramID, validation.Required))
+}
+
+func (bench *DecisionBench) Validate() error {
+	return validation.ValidateStruct(bench,
+		validation.Field(&bench.ID, validation.Required),
+		validation.Field(&bench.Decision, validation.Required))
 }

--- a/internal/handlers/benches/benches.go
+++ b/internal/handlers/benches/benches.go
@@ -1,6 +1,8 @@
 package benches
 
 import (
+	"benches/internal/apperror"
+	_ "benches/internal/domain"
 	"benches/internal/dto"
 	benchesService "benches/internal/service/benches"
 	"benches/pkg/auth"
@@ -20,46 +22,62 @@ func NewBenchesHandler(benches benchesService.Service) *Handler {
 }
 
 func (h *Handler) Register(router *mux.Router, authManager *auth.Manager) {
-	router.HandleFunc("/", h.listBenches).Methods("GET")
+	router.HandleFunc("/", apperror.Middleware(h.listBenches)).Methods("GET")
 	router.HandleFunc("/", h.addBench).Methods("POST")
 
 	// Создание лавочки через telegram
-	router.HandleFunc("/telegram", h.addBenchViaTelegram).Methods("POST")
+	router.HandleFunc("/telegram", apperror.Middleware(h.addBenchViaTelegram)).Methods("POST")
 
+	// Роутер для функционала модерации
 	routerModeration := router.NewRoute().Subrouter()
 	routerModeration.Use(authManager.JWTMiddleware)
-	routerModeration.HandleFunc("/moderation", h.listModerationBench).Methods("GET")
-	routerModeration.HandleFunc("/moderation", h.decisionBench).Methods("POST")
+	// Получение списка всех лавочек на модерации
+	routerModeration.HandleFunc("/moderation", apperror.Middleware(h.listModerationBench)).Methods("GET")
+	// Одобрение или отказ лавочки
+	routerModeration.HandleFunc("/moderation", apperror.Middleware(h.decisionBench)).Methods("POST")
 }
 
-func (h *Handler) listBenches(w http.ResponseWriter, r *http.Request) {
+// @Summary List benches
+// @Description Get list active benches
+// @Tags Benches
+// @Success 200 {object} []domain.Bench
+// @Failure 400 {object}  apperror.AppError
+// @Router /api/v1/benches/ [get]
+func (h *Handler) listBenches(w http.ResponseWriter, r *http.Request) error {
 	benches, err := h.benches.GetListBenches(r.Context(), true)
 	if err != nil {
-		h.ResponseErrorJson(w, "", http.StatusBadRequest)
-		return
+		return err
 	}
 	h.ResponseJson(w, benches, 200)
+	return nil
 }
 
 // @Summary Create bench via telegram
-// @Tags Benches
+// @Tags Benches Moderation
 // @Produce json
 // @Param CreateBenchViaTelegram body dto.CreateBenchViaTelegram true "bench data"
 // @Success 201
 // @Failure 400
 // @Router /api/v1/benches/telegram [post]
-func (h *Handler) addBenchViaTelegram(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) addBenchViaTelegram(w http.ResponseWriter, r *http.Request) error {
 	var bench dto.CreateBenchViaTelegram
 	if err := json.NewDecoder(r.Body).Decode(&bench); err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		return apperror.ErrDecodeData
 	}
+
+	// Валидация
+	if err := bench.Validate(); err != nil {
+		details, _ := json.Marshal(err)
+		return apperror.NewAppError(err, "validation error", details)
+	}
+
 	err := h.benches.CreateBenchViaTelegram(r.Context(), bench)
 	if err != nil {
 		h.ResponseErrorJson(w, fmt.Sprint(err), http.StatusBadRequest)
-		return
+		return nil
 	}
 	w.WriteHeader(http.StatusCreated)
+	return nil
 }
 
 func (h *Handler) addBench(w http.ResponseWriter, r *http.Request) {
@@ -76,35 +94,40 @@ func (h *Handler) addBench(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
-func (h *Handler) listModerationBench(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) listModerationBench(w http.ResponseWriter, r *http.Request) error {
 	role := r.Context().Value("userRole")
 	if role != "admin" {
-		h.ResponseErrorJson(w, "not enough rights", http.StatusForbidden)
-		return
+		return apperror.ErrNotEnoughRights
 	}
 	benches, err := h.benches.GetListBenches(r.Context(), false)
 	if err != nil {
-		h.ResponseErrorJson(w, "", http.StatusBadRequest)
-		return
+		return err
 	}
 	h.ResponseJson(w, benches, 200)
+	return nil
 }
 
-func (h *Handler) decisionBench(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) decisionBench(w http.ResponseWriter, r *http.Request) error {
 	role := r.Context().Value("userRole")
 	if role != "admin" {
 		h.ResponseErrorJson(w, "not enough rights", http.StatusForbidden)
-		return
+		return apperror.ErrNotEnoughRights
 	}
 	var decisionBench dto.DecisionBench
 	if err := json.NewDecoder(r.Body).Decode(&decisionBench); err != nil {
-		h.ResponseErrorJson(w, "wrong data", http.StatusBadRequest)
-		return
+		return apperror.ErrDecodeData
 	}
+
+	// Валидация
+	if err := decisionBench.Validate(); err != nil {
+		details, _ := json.Marshal(err)
+		return apperror.NewAppError(err, "validation error", details)
+	}
+
 	err := h.benches.DecisionBench(r.Context(), decisionBench)
 	if err != nil {
-		h.ResponseErrorJson(w, "failed to update bench", http.StatusBadRequest)
-		return
+		return err
 	}
 	h.ResponseJson(w, map[string]string{"result": "okay"}, http.StatusAccepted)
+	return nil
 }

--- a/internal/service/notifications/mock.go
+++ b/internal/service/notifications/mock.go
@@ -17,7 +17,8 @@ func NewServiceMock(log *zap.Logger, telegramNotificationURL string) *ServiceMoc
 	}
 }
 
-func (s *ServiceMock) SendNotificationInTelegram(ctx context.Context, typeNotification string, userID int, benchID string) {
+func (s *ServiceMock) SendNotificationInTelegram(ctx context.Context, typeNotification string, userID int, benchID string) error {
 	s.log.Info("Send message to telegram", zap.String("notification", typeNotification),
 		zap.Int("user", userID), zap.String("bench", benchID))
+	return nil
 }


### PR DESCRIPTION
1) Добавлена валидация некоторых DTO
Была добавлена валидация для DTO benches на создание лавочки. 

2) Было добавлено поле details, теперь AppError выглядит так:
```
type AppError struct {
  Err     error           `json:"-"`
  Message string          `json:"message,omitempty"`
  Details json.RawMessage `json:"details"`
}
```

Это сделано для того, чтобы можно было возвращать вложенный json. Например, ошибки о валидации отдельных полей.

3) Обновлён swagger для некоторых endpoints benches.