### PR TITLE
Удалена валидация у полей LastName и Username, удалена лишняя строка

### DIFF
--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -16,8 +16,8 @@ func (u *CreateUser) Validate() error {
 	return validation.ValidateStruct(u,
 		validation.Field(&u.ID, validation.Required),
 		validation.Field(&u.FirstName, validation.Required),
-		validation.Field(&u.LastName, validation.Required),
-		validation.Field(&u.Username, validation.Required),
+		validation.Field(&u.LastName),
+		validation.Field(&u.Username),
 		validation.Field(&u.PhotoUrl, validation.Required),
 		validation.Field(&u.AuthDate, validation.Required),
 		validation.Field(&u.Hash, validation.Required))

--- a/internal/handlers/users/users.go
+++ b/internal/handlers/users/users.go
@@ -35,7 +35,6 @@ func (h *Handler) Register(router *mux.Router) {
 func (h *Handler) registerUser(w http.ResponseWriter, r *http.Request) error {
 	var user dto.CreateUser
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		fmt.Println(err)
 		return apperror.ErrIncorrectDataAuth
 	}
 


### PR DESCRIPTION
Убрал проверку на то, что поле обязательное у `LastName`, `Username` в `CreateUser`, т.к telegram позволяет не заполнять эти поля. 

Также удалил лишнею строку в `internal/handlers/users`. 