### PR TITLE
Добавлено приложение для создания данных бота

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
     $ cd benches-backend
     ```
 - установить `.env` файл
+- создать данные для бота в telegram
+  ```console
+  $ go run ./cmd/bot/main.go -username username_bot -tg_id telegram_id
+  ```
 - запустить контейнер
     ```console
     $ docker-compose up --build -d

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"benches/internal/applications/bot"
+	"benches/internal/config"
+	"benches/pkg/logging"
+	"fmt"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		fmt.Errorf("failed to create logger: %v", err)
+	}
+
+	defer logger.Sync() // nolint:errcheck
+
+	cfg := config.GetConfig()
+	appLogger := logging.NewLogger(logger, "bot")
+	_, err = bot.NewApp(cfg, appLogger)
+	if err != nil {
+		appLogger.Fatal("error create app", zap.Error(err))
+	}
+	logger.Info("running application")
+}

--- a/internal/applications/bot/app.go
+++ b/internal/applications/bot/app.go
@@ -1,0 +1,43 @@
+package bot
+
+import (
+	"benches/internal/config"
+	"benches/internal/domain"
+	"benches/internal/repository/postgres"
+	"benches/pkg/database"
+	"context"
+	"flag"
+	"github.com/uptrace/bun"
+	"go.uber.org/zap"
+)
+
+type App struct {
+	cfg      *config.Config
+	logger   *zap.Logger
+	database *bun.DB
+}
+
+func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
+	logger.Info("database initializing")
+	db := postgres.NewPostgresDatabase(database.DatabaseParametersToDSN("postgres", cfg.PostgreSQL.Host,
+		cfg.PostgreSQL.Database, cfg.PostgreSQL.Username, cfg.PostgreSQL.Password, false))
+
+	username := flag.String("username", "admin", "Enter username bot")
+	telegramID := flag.Int("tg_id", 0, "Enter tg_id bot")
+
+	flag.Parse()
+
+	appUsersRepository := postgres.NewUsersRepository(db)
+
+	user := domain.User{
+		Username:   *username,
+		TelegramID: *telegramID,
+		Role:       "bot",
+	}
+	appUsersRepository.CreateUser(context.TODO(), user)
+	return &App{
+		cfg:      cfg,
+		logger:   logger,
+		database: db,
+	}, nil
+}


### PR DESCRIPTION
Данное приложение нужно лишь для того, чтобы создать данные бота в БД. Лезть в БД руками теперь не нужно. 

Команда:
```
$ go run ./cmd/bot/main.go -username username_bot -tg_id telegram_id
```

Может быть, в дальнейшем, будет переписано на gateway.