### PR TITLE
Добавлен функционал обновления комментария

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -219,6 +219,34 @@ const docTemplate = `{
                         "description": "Bad Request"
                     }
                 }
+            },
+            "patch": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Comments"
+                ],
+                "summary": "Update comment",
+                "parameters": [
+                    {
+                        "description": "comment data",
+                        "name": "UpdateComment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateComment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
             }
         },
         "/api/v1/comments/{id}": {
@@ -558,6 +586,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UpdateComment": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -207,6 +207,34 @@
                         "description": "Bad Request"
                     }
                 }
+            },
+            "patch": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Comments"
+                ],
+                "summary": "Update comment",
+                "parameters": [
+                    {
+                        "description": "comment data",
+                        "name": "UpdateComment",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateComment"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
             }
         },
         "/api/v1/comments/{id}": {
@@ -546,6 +574,17 @@
             "type": "object",
             "properties": {
                 "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.UpdateComment": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -115,6 +115,13 @@ definitions:
       token:
         type: string
     type: object
+  dto.UpdateComment:
+    properties:
+      content:
+        type: string
+      id:
+        type: string
+    type: object
 info:
   contact: {}
 paths:
@@ -232,6 +239,24 @@ paths:
       tags:
       - Bot
   /api/v1/comments:
+    patch:
+      parameters:
+      - description: comment data
+        in: body
+        name: UpdateComment
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdateComment'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+      summary: Update comment
+      tags:
+      - Comments
     post:
       parameters:
       - description: comment data

--- a/internal/applications/initiator/app.go
+++ b/internal/applications/initiator/app.go
@@ -130,7 +130,7 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 	appCommentsRepository := postgres.NewCommentsRepository(db)
 	appCommentsService := commentsService.NewService(appCommentsRepository, logger)
 	appHandlerComments := comments.NewCommentsHandler(appCommentsService, appUsersService)
-	appHandlerComments.Register(appCommentsRouter)
+	appHandlerComments.Register(appCommentsRouter, authManager)
 
 	return &App{cfg: cfg, logger: logger, router: router}, nil
 }

--- a/internal/dto/comments.go
+++ b/internal/dto/comments.go
@@ -12,6 +12,11 @@ type CreateComment struct {
 	Content  string `json:"content"`
 }
 
+type UpdateComment struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+}
+
 func (comment *CreateComment) Validate() error {
 	return validation.ValidateStruct(comment,
 		validation.Field(&comment.BenchID, validation.Required),
@@ -25,5 +30,17 @@ func (comment *CreateComment) ToDomain() domain.Comment {
 		ParentID: comment.ParentID,
 		AuthorID: comment.AuthorID,
 		Content:  comment.Content,
+	}
+}
+
+func (comment *UpdateComment) Validate() error {
+	return validation.ValidateStruct(comment,
+		validation.Field(&comment.ID, validation.Required))
+}
+
+func (comment *UpdateComment) ToDomain() domain.Comment {
+	return domain.Comment{
+		ID:      comment.ID,
+		Content: comment.Content,
 	}
 }

--- a/internal/repository/postgres/comments.go
+++ b/internal/repository/postgres/comments.go
@@ -30,6 +30,7 @@ func commentModelToDomain(model commentModel) domain.Comment {
 		ID:       model.ID,
 		BenchID:  model.BenchID,
 		ParentID: model.ParentID,
+		AuthorID: model.AuthorID,
 		Content:  model.Content,
 	}
 }

--- a/internal/repository/postgres/comments_repository.go
+++ b/internal/repository/postgres/comments_repository.go
@@ -11,6 +11,8 @@ type CommentsRepository interface {
 	GetByBenchID(ctx context.Context, id string) ([]domain.Comment, error)
 	GetByParentID(ctx context.Context, id string) ([]domain.Comment, error)
 	CreateComment(ctx context.Context, bench domain.Comment) error
+	Update(ctx context.Context, comment domain.Comment) error
+	GetByID(ctx context.Context, id string) (domain.Comment, error)
 }
 
 type commentsRepository struct {
@@ -43,6 +45,17 @@ func (repository *commentsRepository) GetByParentID(ctx context.Context, id stri
 	return comments, nil
 }
 
+// GetByID Получение комментария по ID
+func (repository *commentsRepository) GetByID(ctx context.Context, id string) (domain.Comment, error) {
+	comment := commentModel{}
+	err := repository.db.NewSelect().Model(&comment).Where("comments.id = ?", id).Scan(ctx)
+	if err != nil {
+		return domain.Comment{}, err
+	}
+	return commentModelToDomain(comment), nil
+}
+
+// CreateComment Создание комментария
 func (repository *commentsRepository) CreateComment(ctx context.Context, comment domain.Comment) error {
 	model := commentModel{}
 	model.FromDomain(comment)
@@ -51,5 +64,23 @@ func (repository *commentsRepository) CreateComment(ctx context.Context, comment
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// Update Обновление комментария
+func (repository *commentsRepository) Update(ctx context.Context, comment domain.Comment) error {
+	model := commentModel{}
+	model.FromDomain(comment)
+
+	_, err := repository.db.NewUpdate().
+		Model(&model).
+		OmitZero().
+		WherePK().
+		Exec(ctx)
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/transport/httpv1/comments/comments.go
+++ b/internal/transport/httpv1/comments/comments.go
@@ -6,6 +6,7 @@ import (
 	"benches/internal/dto"
 	commentsService "benches/internal/service/comments"
 	usersService "benches/internal/service/users"
+	"benches/pkg/auth"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -26,8 +27,13 @@ func NewCommentsHandler(comments commentsService.Service, usersService usersServ
 	}
 }
 
-func (handler *Handler) Register(router *mux.Router) {
+func (handler *Handler) Register(router *mux.Router, authManager *auth.Manager) {
 	router.HandleFunc("/{id}", apperror.Middleware(handler.listCommentsByBench))
+
+	interactionCommentRouter := router.NewRoute().Subrouter()
+	interactionCommentRouter.Use(authManager.JWTMiddleware)
+	interactionCommentRouter.HandleFunc("", apperror.Middleware(handler.createComment)).Methods("POST")
+	interactionCommentRouter.HandleFunc("", apperror.Middleware(handler.updateComment)).Methods("PATCH")
 }
 
 // @Summary List comments by bench
@@ -89,5 +95,34 @@ func (handler *Handler) createComment(writer http.ResponseWriter, request *http.
 	}
 
 	writer.WriteHeader(http.StatusCreated)
+	return nil
+}
+
+// @Summary Update comment
+// @Tags Comments
+// @Produce json
+// @Param UpdateComment body dto.UpdateComment true "comment data"
+// @Success 200
+// @Failure 400
+// @Router /api/v1/comments [patch]
+func (handler *Handler) updateComment(writer http.ResponseWriter, request *http.Request) error {
+	var comment dto.UpdateComment
+	if err := json.NewDecoder(request.Body).Decode(&comment); err != nil {
+		return apperror.ErrDecodeData
+	}
+
+	// Валидация
+	if errValidate := comment.Validate(); errValidate != nil {
+		details, _ := json.Marshal(errValidate)
+		return apperror.NewAppError(errValidate, "validation error", details)
+	}
+
+	// Обновление комментария
+	errUpdate := handler.comments.UpdateComment(request.Context(), comment.ToDomain())
+	if errUpdate != nil {
+		return errUpdate
+	}
+
+	writer.WriteHeader(http.StatusOK)
 	return nil
 }

--- a/internal/transport/httpv1/comments/comments.go
+++ b/internal/transport/httpv1/comments/comments.go
@@ -117,6 +117,17 @@ func (handler *Handler) updateComment(writer http.ResponseWriter, request *http.
 		return apperror.NewAppError(errValidate, "validation error", details)
 	}
 
+	// Проверка на владельца комментария
+	isOwner, errIsOwner := handler.comments.IsOwner(
+		request.Context(), comment.ID, request.Context().Value("userID").(string))
+	if errIsOwner != nil {
+		return errIsOwner
+	}
+
+	if !isOwner {
+		return apperror.ErrNotEnoughRights
+	}
+
 	// Обновление комментария
 	errUpdate := handler.comments.UpdateComment(request.Context(), comment.ToDomain())
 	if errUpdate != nil {


### PR DESCRIPTION
Проверка на возможность обновления вынесена в handler, обновить комментарий может только владелец. 

Добавлен метод у сервис `IsOwner`, который проверяет, принадлежит ли этот комментарий данному человеку.