### PR TITLE
Удалено поле комментариев из Bench и добавлены ошибки строго формата в pkg/auth

### DIFF
--- a/internal/domain/benches.go
+++ b/internal/domain/benches.go
@@ -1,12 +1,11 @@
 package domain
 
 type Bench struct {
-	ID       string    `json:"id,pk"`
-	Lat      float64   `json:"lat"`
-	Lng      float64   `json:"lng"`
-	Images   []string  `json:"images"`
-	IsActive bool      `json:"is_active"`
-	Tags     []Tag     `json:"tags"`
-	Comments []Comment `json:"comments"`
-	Owner    *User     `json:"-"`
+	ID       string   `json:"id,pk"`
+	Lat      float64  `json:"lat"`
+	Lng      float64  `json:"lng"`
+	Images   []string `json:"images"`
+	IsActive bool     `json:"is_active"`
+	Tags     []Tag    `json:"tags"`
+	Owner    *User    `json:"-"`
 }

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -112,7 +112,11 @@ func (m *Manager) checkJWT(w http.ResponseWriter, r *http.Request) (context.Cont
 	authHeader := strings.Split(r.Header.Get("Authorization"), "Bearer ")
 	if len(authHeader) != 2 {
 		w.WriteHeader(http.StatusUnauthorized)
-		_, err := w.Write([]byte("Malformed Token"))
+		errorResponse := ErrorResponse{
+			Message: "malformed token",
+			Details: nil,
+		}
+		_, err := w.Write(errorResponse.Marshal()) // nolint: errcheck
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
@@ -128,7 +132,11 @@ func (m *Manager) checkJWT(w http.ResponseWriter, r *http.Request) (context.Cont
 
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte("Unauthorized"))
+		errorResponse := ErrorResponse{
+			Message: "Unauthorized",
+			Details: nil,
+		}
+		_, _ = w.Write(errorResponse.Marshal())
 		return nil, err
 	}
 
@@ -137,8 +145,12 @@ func (m *Manager) checkJWT(w http.ResponseWriter, r *http.Request) (context.Cont
 		ctx = context.WithValue(ctx, "userRole", claims["role"])
 		return ctx, nil
 	} else {
+		errorResponse := ErrorResponse{
+			Message: "Unauthorized",
+			Details: nil,
+		}
 		w.WriteHeader(http.StatusUnauthorized)
-		_, err2 := w.Write([]byte("Unauthorized"))
+		_, err2 := w.Write(errorResponse.Marshal())
 
 		if err2 != nil {
 			return nil, err

--- a/pkg/auth/response.go
+++ b/pkg/auth/response.go
@@ -1,0 +1,21 @@
+package auth
+
+import "encoding/json"
+
+type ErrorResponse struct {
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details"`
+}
+
+type JSONMarshal interface {
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(data []byte) error
+}
+
+func (e *ErrorResponse) Marshal() []byte {
+	marshal, err := json.Marshal(e)
+	if err != nil {
+		return nil
+	}
+	return marshal
+}


### PR DESCRIPTION
Теперь ошибки в `pkg/auth` отдаётся аналогично, как и во всём приложении. 

Close #87 