### PR TITLE
Удалён AuthorID из DTO и разрешено значение null. Ошибки pkg/auth теперь в lower case

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -664,9 +664,6 @@ const docTemplate = `{
         "dto.CreateComment": {
             "type": "object",
             "properties": {
-                "author_id": {
-                    "type": "string"
-                },
                 "bench_id": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -652,9 +652,6 @@
         "dto.CreateComment": {
             "type": "object",
             "properties": {
-                "author_id": {
-                    "type": "string"
-                },
                 "bench_id": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -75,8 +75,6 @@ definitions:
     type: object
   dto.CreateComment:
     properties:
-      author_id:
-        type: string
       bench_id:
         type: string
       content:

--- a/internal/dto/comments.go
+++ b/internal/dto/comments.go
@@ -8,7 +8,6 @@ import (
 type CreateComment struct {
 	BenchID  string `json:"bench_id"`
 	ParentID string `json:"parent_id"`
-	AuthorID string `json:"author_id"`
 	Content  string `json:"content"`
 }
 
@@ -20,7 +19,6 @@ type UpdateComment struct {
 func (comment *CreateComment) Validate() error {
 	return validation.ValidateStruct(comment,
 		validation.Field(&comment.BenchID, validation.Required),
-		validation.Field(&comment.AuthorID, validation.Required),
 		validation.Field(&comment.Content, validation.Required))
 }
 
@@ -28,7 +26,6 @@ func (comment *CreateComment) ToDomain() domain.Comment {
 	return domain.Comment{
 		BenchID:  comment.BenchID,
 		ParentID: comment.ParentID,
-		AuthorID: comment.AuthorID,
 		Content:  comment.Content,
 	}
 }

--- a/internal/repository/postgres/comments.go
+++ b/internal/repository/postgres/comments.go
@@ -11,7 +11,7 @@ type commentModel struct {
 	ID       string      `bun:"id,pk"`
 	BenchID  string      `bun:"bench_id"`
 	Bench    *benchModel `bun:"rel:belongs-to,join:bench_id=id"`
-	ParentID string      `bun:"parent_id"`
+	ParentID string      `bun:"parent_id,nullzero"`
 	AuthorID string      `bun:"author_id"`
 	Author   *userModel  `bun:"rel:belongs-to,join:author_id=id"`
 	Content  string      `bun:"content"`

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -133,7 +133,7 @@ func (m *Manager) checkJWT(w http.ResponseWriter, r *http.Request) (context.Cont
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		errorResponse := ErrorResponse{
-			Message: "Unauthorized",
+			Message: "unauthorized",
 			Details: nil,
 		}
 		_, _ = w.Write(errorResponse.Marshal())
@@ -146,7 +146,7 @@ func (m *Manager) checkJWT(w http.ResponseWriter, r *http.Request) (context.Cont
 		return ctx, nil
 	} else {
 		errorResponse := ErrorResponse{
-			Message: "Unauthorized",
+			Message: "unauthorized",
 			Details: nil,
 		}
 		w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Было удалено поле `AuthorID` из DTO, потому что это поле берётся из JWT. 

Теперь в `pkg/auth` все ошибки начинаются с маленькой буквы.