### PR TITLE
Исправлены координаты лавочек в репозитории

### DIFF
--- a/internal/repository/postgres/benches/repository.go
+++ b/internal/repository/postgres/benches/repository.go
@@ -59,8 +59,8 @@ func (repository *repository) All(ctx context.Context, isActive bool, sortOption
 		bench := domain.Bench{}
 		if err = rows.Scan(
 			&bench.ID,
-			&bench.Lng,
 			&bench.Lat,
+			&bench.Lng,
 			&bench.IsActive,
 			&bench.Images,
 			&bench.Owner,


### PR DESCRIPTION
`lat` и `lng` были перепутаны местами. Поменял обратно. 