### PR TITLE
Исправлено ошибка с отсутствием результата при запросе в БД

### DIFF
--- a/internal/repository/postgres/benches/repository.go
+++ b/internal/repository/postgres/benches/repository.go
@@ -81,7 +81,7 @@ func (repository *repository) All(ctx context.Context, isActive bool, sortOption
 func (repository *repository) ByID(ctx context.Context, id string) (*domain.Bench, error) {
 	sql, args, errBuild := repository.queryBuilder.
 		Select("id").
-		Columns("lat", "lng", "is_active", "images", "owner").
+		Columns("lat", "lng", "is_active", "images", "owner_id").
 		From(tableScheme).Where(squirrel.Eq{"id": id}).ToSql()
 
 	if errBuild != nil {

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -8,7 +8,9 @@ import (
 	storage "benches/internal/storage/minio"
 	"benches/pkg/api/sort"
 	"context"
+	"errors"
 	"fmt"
+	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"go.uber.org/zap"
 )
@@ -82,6 +84,10 @@ func (service *service) GetBenchByID(ctx context.Context, id string) (*domain.Be
 	// Получаем лавочку по ID из базы данных
 	bench, err := service.db.ByID(ctx, id)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return bench, apperror.ErrNotFound
+		}
+		service.log.Error("get bench by id", zap.Error(err))
 		return bench, err
 	}
 

--- a/internal/service/users/service.go
+++ b/internal/service/users/service.go
@@ -40,9 +40,8 @@ func (service *service) LoginViaTelegram(ctx context.Context, telegramUser domai
 	}
 
 	dbUser, err := service.db.ByTelegramID(ctx, telegramUser.ID)
-	if err == sql.ErrNoRows {
-		var errCreate error
-		errCreate = service.db.Create(ctx, user)
+	if errors.Is(err, sql.ErrNoRows) {
+		errCreate := service.db.Create(ctx, user)
 		if errCreate != nil {
 			return "", "", errCreate
 		}

--- a/internal/transport/httpv1/benches/benches.go
+++ b/internal/transport/httpv1/benches/benches.go
@@ -7,9 +7,7 @@ import (
 	"benches/internal/policy/benches"
 	"benches/pkg/api/sort"
 	"benches/pkg/auth"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"github.com/gorilla/mux"
 	"net/http"
 )
@@ -73,14 +71,12 @@ func (handler *Handler) listBenches(w http.ResponseWriter, r *http.Request) erro
 func (handler *Handler) detailBench(w http.ResponseWriter, r *http.Request) error {
 	id := mux.Vars(r)["id"]
 	bench, err := handler.policy.GetBenchByID(r.Context(), id)
+	if err != nil {
+		return err
+	}
+
 	if !bench.IsActive {
 		return apperror.ErrNotFound
-	}
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return apperror.ErrNotFound
-		}
-		return err
 	}
 	handler.ResponseJson(w, bench, http.StatusOK)
 	return nil

--- a/internal/transport/httpv1/comments/comments.go
+++ b/internal/transport/httpv1/comments/comments.go
@@ -6,10 +6,10 @@ import (
 	"benches/internal/dto"
 	commentsPolicy "benches/internal/policy/comments"
 	"benches/pkg/auth"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5"
 	"net/http"
 )
 
@@ -45,7 +45,7 @@ func (handler *Handler) listCommentsByBench(writer http.ResponseWriter, request 
 
 	comments, err := handler.policy.GetAllCommentByBench(request.Context(), id)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return apperror.ErrNotFound
 		}
 		return err


### PR DESCRIPTION
Как оказалось, теперь тип ошибки `pgx.ErrNoRows`, а не `sql.ErrNoRows`. 

`sql.ErrNoRows` было изменено на  `pgx.ErrNoRows`. Также исправлена ошибка в `ByID` для benches, ведь поля `owner` не существует. Этот параметр был переименован на `owner_id`.

Close #116 