### PR TITLE
Исправлена ошибка с 403 и адекватным ответом

### DIFF
--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -101,6 +101,7 @@ func (m *Manager) JWTRoleMiddleware(role string) func(next http.Handler) http.Ha
 			userRole := ctx.Value("userRole")
 			if userRole != role {
 				w.WriteHeader(http.StatusForbidden)
+				return
 			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
Ранее при запросе на получения всех лавочек на модерации, сервер отдавал 403 и всех лавочки, чего быть не должно.

Проблема была в том, что в `JWTRoleMiddleware` не происходил `return` при условии, что роль не подходит.

Close #124 