### PR TITLE
Добавлены новые параметры для пагинации

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -45,7 +45,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "pre page",
-                        "name": "pre_page",
+                        "name": "per_page",
                         "in": "query"
                     }
                 ],
@@ -142,7 +142,7 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "description": "pre page",
-                        "name": "pre_page",
+                        "name": "per_page",
                         "in": "query"
                     }
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -53,10 +53,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Bench"
-                            }
+                            "$ref": "#/definitions/domain.BenchesList"
                         }
                     },
                     "400": {
@@ -802,6 +799,20 @@ const docTemplate = `{
                 },
                 "owner": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.BenchesList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Bench"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -41,10 +41,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.Bench"
-                            }
+                            "$ref": "#/definitions/domain.BenchesList"
                         }
                     },
                     "400": {
@@ -790,6 +787,20 @@
                 },
                 "owner": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.BenchesList": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Bench"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -33,7 +33,7 @@
                     {
                         "type": "integer",
                         "description": "pre page",
-                        "name": "pre_page",
+                        "name": "per_page",
                         "in": "query"
                     }
                 ],
@@ -130,7 +130,7 @@
                     {
                         "type": "integer",
                         "description": "pre page",
-                        "name": "pre_page",
+                        "name": "per_page",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -25,6 +25,15 @@ definitions:
       owner:
         type: string
     type: object
+  domain.BenchesList:
+    properties:
+      count:
+        type: integer
+      items:
+        items:
+          $ref: '#/definitions/domain.Bench'
+        type: array
+    type: object
   domain.Comment:
     properties:
       author_id:
@@ -203,9 +212,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/domain.Bench'
-            type: array
+            $ref: '#/definitions/domain.BenchesList'
         "400":
           description: Bad Request
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -197,7 +197,7 @@ paths:
         type: integer
       - description: pre page
         in: query
-        name: pre_page
+        name: per_page
         type: integer
       responses:
         "200":
@@ -333,7 +333,7 @@ paths:
         type: integer
       - description: pre page
         in: query
-        name: pre_page
+        name: per_page
         type: integer
       responses:
         "200":

--- a/internal/domain/benches.go
+++ b/internal/domain/benches.go
@@ -8,3 +8,15 @@ type Bench struct {
 	IsActive bool     `json:"is_active"`
 	Owner    string   `json:"owner"`
 }
+
+type BenchesList struct {
+	Count int      `json:"count"`
+	Items []*Bench `json:"items"`
+}
+
+func NewBenchesList(benches []*Bench, count int) BenchesList {
+	return BenchesList{
+		Count: count,
+		Items: benches,
+	}
+}

--- a/internal/policy/benches/policy.go
+++ b/internal/policy/benches/policy.go
@@ -49,8 +49,21 @@ func (policy *Policy) CreateBenchViaTelegram(ctx context.Context, userTelegramID
 }
 
 func (policy *Policy) GetListBenches(ctx context.Context, isActive bool, sortOptions sort.Options,
-	paginateOptions paginate.Options) ([]*domain.Bench, error) {
-	return policy.benchesService.GetListBenches(ctx, isActive, sortOptions, paginateOptions)
+	paginateOptions paginate.Options) (domain.BenchesList, error) {
+
+	all, errGetList := policy.benchesService.GetListBenches(ctx, isActive, sortOptions, paginateOptions)
+	if errGetList != nil {
+		return domain.BenchesList{}, errGetList
+	}
+
+	count, errGetCount := policy.benchesService.CountAllBenches(ctx, isActive)
+	if errGetCount != nil {
+		return domain.BenchesList{}, errGetCount
+	}
+
+	list := domain.NewBenchesList(all, count)
+
+	return list, nil
 }
 
 func (policy *Policy) CreateBench(ctx context.Context, bench domain.Bench) error {

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -25,6 +25,7 @@ type Service interface {
 	SaveImages(ctx context.Context, images [][]byte) ([]string, error)
 	UpdateBench(ctx context.Context, id string, bench domain.Bench) error
 	DeleteBench(ctx context.Context, id string) error
+	CountAllBenches(ctx context.Context, isActive bool) (int, error)
 }
 
 type service struct {
@@ -60,6 +61,16 @@ func (service *service) GetListBenches(ctx context.Context, isActive bool, sortO
 	}
 
 	return all, nil
+}
+
+func (service *service) CountAllBenches(ctx context.Context, isActive bool) (int, error) {
+	count, err := service.db.Count(ctx, isActive)
+	if err != nil {
+		service.log.Error("get count all benches", zap.Error(err))
+		return 0, err
+	}
+
+	return count, nil
 }
 
 func (service *service) CreateBench(ctx context.Context, bench domain.Bench) error {


### PR DESCRIPTION
Теперь возвращаемый объект выглядит так:
```
{
    count: int,
    items: []
}
```

Обновлён swagger. Переименован параметр с `pre_page` на `per_page`.