### PR TITLE
fix: FD-13 | Изменена логика клика на кластер

### DIFF
--- a/app/components/ui/Benches/BenchesMap/BenchesMapPlacemarks/index.tsx
+++ b/app/components/ui/Benches/BenchesMap/BenchesMapPlacemarks/index.tsx
@@ -8,15 +8,15 @@ interface IProps {
   benches?: BenchType[]
 }
 
-const renderBalloonImage = (images: string[]): ReactElement | '' => {
-  return images.length ? <img src={images[0]} alt="" /> : ''
+const renderBalloonImage = (images: string[]): string => {
+  return images.length ? `<img src='${images[0]}' alt="" />` : ''
 }
 
 const getPointData = (bench: BenchType): MapBalloonType => {
   const balloonBody =
       `<div class="benches-map__balloon-image">
+            <div>Лавочка <strong>#${bench.id}</strong></div>
             ${renderBalloonImage(bench.images)}
-            <div>Лавочка <strong>#${bench.id}</div>
         </div>
         `
 
@@ -68,9 +68,9 @@ const BenchesMapPlacemarks: FC<IProps> = ({
       options={{
         preset: 'islands#invertedVioletClusterIcons',
         groupByCoordinates: false,
-        clusterDisableClickZoom: true,
-        clusterHideIconOnBalloonOpen: false,
-        geoObjectHideIconOnBalloonOpen: false,
+        clusterDisableClickZoom: false,
+        clusterHideIconOnBalloonOpen: true,
+        geoObjectHideIconOnBalloonOpen: true,
         clusterIconColor: '#49260a'
       }}
     >

--- a/app/components/ui/Benches/BenchesMap/index.tsx
+++ b/app/components/ui/Benches/BenchesMap/index.tsx
@@ -49,13 +49,18 @@ const BenchesMap: FC<IProps> = (
       <Map
         version={'2.1.79'}
         state={mapState}
-        width='100%'
+        width={'100%'}
         height={height}
         instanceRef={setMap}
         onLoad={(ymaps) => {
           setMap(ymaps)
         }}
-        modules={['geolocation', 'geocode', 'geoObject.addon.balloon', 'geoObject.addon.hint']}
+        modules={[
+          'geolocation',
+          'geocode',
+          'geoObject.addon.balloon',
+          'geoObject.addon.hint'
+        ]}
       >
         <BenchesMapPlacemarks
           benches={benches}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,7 +38,9 @@ const HomePage: NextPage = (): ReactElement => {
 
           const newBenches = [...benches.items]
 
-          newBenches[index] = Object.assign(bench, { address: firstGeoObjectLocation })
+          newBenches[index] = Object.assign(bench,
+            { address: firstGeoObjectLocation }
+          )
 
           setBenches({
             ...benches,


### PR DESCRIPTION
Теперь при клике происходит зум, а не отображение лавочек, находящихся в этом кластере.
Fixes #110 