### PR TITLE
Исправлена ошибка с падением Redis

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       retries: 5
 
   redis:
-    image: bitnami/redis:7.0.5
+    image: redis:7.0
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
Сервис `redis` перешёл на версию `redis:7.0`. Падений больше не наблюдается. 

Close #136