### PR TITLE
Добавлен endpoint для получения всех лавочек без ограничений, исправлен комментарий для swagger

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -18,11 +18,11 @@ const docTemplate = `{
     "paths": {
         "/api/v1/benches": {
             "get": {
-                "description": "Get list active benches",
+                "description": "Get a list of benches with filtering and pagination",
                 "tags": [
                     "Benches"
                 ],
-                "summary": "List benches",
+                "summary": "List benches with filtering and pagination",
                 "parameters": [
                     {
                         "type": "string",
@@ -44,7 +44,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "pre page",
+                        "description": "per page",
                         "name": "per_page",
                         "in": "query"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,11 +6,11 @@
     "paths": {
         "/api/v1/benches": {
             "get": {
-                "description": "Get list active benches",
+                "description": "Get a list of benches with filtering and pagination",
                 "tags": [
                     "Benches"
                 ],
-                "summary": "List benches",
+                "summary": "List benches with filtering and pagination",
                 "parameters": [
                     {
                         "type": "string",
@@ -32,7 +32,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "pre page",
+                        "description": "per page",
                         "name": "per_page",
                         "in": "query"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -190,7 +190,7 @@ info:
 paths:
   /api/v1/benches:
     get:
-      description: Get list active benches
+      description: Get a list of benches with filtering and pagination
       parameters:
       - description: sort field
         in: query
@@ -204,7 +204,7 @@ paths:
         in: query
         name: page
         type: integer
-      - description: pre page
+      - description: per page
         in: query
         name: per_page
         type: integer
@@ -217,7 +217,7 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/apperror.AppError'
-      summary: List benches
+      summary: List benches with filtering and pagination
       tags:
       - Benches
     post:

--- a/internal/policy/benches/policy.go
+++ b/internal/policy/benches/policy.go
@@ -48,8 +48,8 @@ func (policy *Policy) CreateBenchViaTelegram(ctx context.Context, userTelegramID
 	return nil
 }
 
-func (policy *Policy) GetListBenches(ctx context.Context, isActive bool, sortOptions sort.Options,
-	paginateOptions paginate.Options) (domain.BenchesList, error) {
+func (policy *Policy) GetListBenches(ctx context.Context, isActive bool, sortOptions *sort.Options,
+	paginateOptions *paginate.Options) (domain.BenchesList, error) {
 
 	all, errGetList := policy.benchesService.GetListBenches(ctx, isActive, sortOptions, paginateOptions)
 	if errGetList != nil {

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -17,8 +17,8 @@ import (
 )
 
 type Service interface {
-	GetListBenches(ctx context.Context, isActive bool, sortOptions sort.Options,
-		paginateOptions paginate.Options) ([]*domain.Bench, error)
+	GetListBenches(ctx context.Context, isActive bool, sortOptions *sort.Options,
+		paginateOptions *paginate.Options) ([]*domain.Bench, error)
 	CreateBench(ctx context.Context, bench domain.Bench) error
 	DecisionBench(ctx context.Context, benchID string, decision bool) error
 	GetBenchByID(ctx context.Context, id string) (*domain.Bench, error)
@@ -38,13 +38,21 @@ func NewService(db benches.Repository, storage *storage.Storage, log *zap.Logger
 	return &service{db: db, storage: storage, log: log}
 }
 
-func (service *service) GetListBenches(ctx context.Context, isActive bool, sortOptions sort.Options,
-	paginateOptions paginate.Options) ([]*domain.Bench, error) {
+func (service *service) GetListBenches(ctx context.Context, isActive bool, sortOptions *sort.Options,
+	paginateOptions *paginate.Options) ([]*domain.Bench, error) {
+
+	var optionsForSort model.SortOptions
+	var optionsForPaginate model.PaginateOptions
+
 	// Создаём параметры для сортировки
-	optionsForSort := model.NewSortOptions(sortOptions.Field, sortOptions.Order)
+	if sortOptions != nil {
+		optionsForSort = model.NewSortOptions(sortOptions.Field, sortOptions.Order)
+	}
 
 	// Создаём параметры для пагинации
-	optionsForPaginate := model.NewPaginateOptions(paginateOptions.Page, paginateOptions.PerPage)
+	if paginateOptions != nil {
+		optionsForPaginate = model.NewPaginateOptions(paginateOptions.Page, paginateOptions.PerPage)
+	}
 
 	// Получаем все лавочки из базы данных
 	all, err := service.db.All(ctx, isActive, optionsForSort, optionsForPaginate)

--- a/internal/transport/httpv1/benches/benches.go
+++ b/internal/transport/httpv1/benches/benches.go
@@ -23,6 +23,7 @@ func NewHandler(benches *benches.Policy) *Handler {
 }
 
 func (handler *Handler) Register(router *mux.Router, authManager *auth.Manager) {
+	router.HandleFunc("/all", apperror.Middleware(handler.allListBenches)).Methods("GET")
 	router.HandleFunc("", paginate.Middleware(sort.Middleware(
 		apperror.Middleware(handler.listBenches), "id", sort.ASC), 1, 10)).Methods("GET")
 
@@ -49,8 +50,26 @@ func (handler *Handler) Register(router *mux.Router, authManager *auth.Manager) 
 	router.HandleFunc("/{id}", apperror.Middleware(handler.detailBench)).Methods("GET")
 }
 
-// @Summary List benches
-// @Description Get list active benches
+// @Summary All list benches
+// @Description Get all the benches
+// @Tags Benches
+// @Success 200 {object} domain.BenchesList
+// @Failure 400 {object} apperror.AppError
+// @Router /api/v1/benches [get]
+func (handler *Handler) allListBenches(writer http.ResponseWriter, request *http.Request) error {
+	all, errGetAll := handler.policy.GetListBenches(
+		request.Context(), true, nil, nil)
+
+	if errGetAll != nil {
+		return errGetAll
+	}
+
+	handler.ResponseJson(writer, all, 200)
+	return nil
+}
+
+// @Summary List benches with filtering and pagination
+// @Description Get a list of benches with filtering and pagination
 // @Tags Benches
 // @Param sort_by query string false "sort field"
 // @Param sort_order query string false "sort order"
@@ -61,15 +80,15 @@ func (handler *Handler) Register(router *mux.Router, authManager *auth.Manager) 
 // @Router /api/v1/benches [get]
 func (handler *Handler) listBenches(writer http.ResponseWriter, request *http.Request) error {
 	// Получаем параметры для сортировки
-	var sortOptions sort.Options
+	var sortOptions *sort.Options
 	if options, ok := request.Context().Value(sort.OptionsContextKey).(sort.Options); ok {
-		sortOptions = options
+		sortOptions = &options
 	}
 
 	// Получаем параметры для пагинации
-	var paginateOptions paginate.Options
+	var paginateOptions *paginate.Options
 	if options, ok := request.Context().Value(paginate.OptionsContextKey).(paginate.Options); ok {
-		paginateOptions = options
+		paginateOptions = &options
 	}
 
 	all, err := handler.policy.GetListBenches(request.Context(), true, sortOptions, paginateOptions)
@@ -223,15 +242,15 @@ func (handler *Handler) deleteBench(writer http.ResponseWriter, request *http.Re
 // @Router /api/v1/benches/moderation [get]
 func (handler *Handler) listModerationBench(writer http.ResponseWriter, request *http.Request) error {
 	// Получаем параметры для сортировки
-	var sortOptions sort.Options
+	var sortOptions *sort.Options
 	if options, ok := request.Context().Value(sort.OptionsContextKey).(sort.Options); ok {
-		sortOptions = options
+		sortOptions = &options
 	}
 
 	// Получаем параметры для пагинации
-	var paginateOptions paginate.Options
+	var paginateOptions *paginate.Options
 	if options, ok := request.Context().Value(paginate.OptionsContextKey).(paginate.Options); ok {
-		paginateOptions = options
+		paginateOptions = &options
 	}
 
 	all, err := handler.policy.GetListBenches(request.Context(), false, sortOptions, paginateOptions)

--- a/internal/transport/httpv1/benches/benches.go
+++ b/internal/transport/httpv1/benches/benches.go
@@ -55,8 +55,8 @@ func (handler *Handler) Register(router *mux.Router, authManager *auth.Manager) 
 // @Param sort_by query string false "sort field"
 // @Param sort_order query string false "sort order"
 // @Param page query int false "page"
-// @Param pre_page query int false "pre page"
-// @Success 200 {object} []domain.Bench
+// @Param per_page query int false "per page"
+// @Success 200 {object} domain.BenchesList
 // @Failure 400 {object} apperror.AppError
 // @Router /api/v1/benches [get]
 func (handler *Handler) listBenches(writer http.ResponseWriter, request *http.Request) error {
@@ -217,7 +217,7 @@ func (handler *Handler) deleteBench(writer http.ResponseWriter, request *http.Re
 // @Param sort_by query string false "sort field"
 // @Param sort_order query string false "sort order"
 // @Param page query int false "page"
-// @Param pre_page query int false "pre page"
+// @Param per_page query int false "pre page"
 // @Success 200 {object} []domain.Bench
 // @Failure 400 {object} apperror.AppError
 // @Router /api/v1/benches/moderation [get]


### PR DESCRIPTION
Был добавлен `GET /api/v1/benches/all` для получения всех лавочек, без ограничений на пагинацию или сортировку. 

`pre_page` был переименован в `per_page`. 

Close #169