### PR TITLE
Исправлен баг с созданием лавочки с улицей, добавлена возможность сразу создавать лавочку с тегами

### DIFF
--- a/internal/applications/initiator/app.go
+++ b/internal/applications/initiator/app.go
@@ -114,6 +114,14 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 		appNotificationsService = notificationsService.NewService(logger, cfg.Telegram.NotificationToken)
 	}
 
+	// Теги
+	appTagsRouter := router.PathPrefix("/api/v1/tags").Subrouter()
+	appTagsRepository := tagsRepository.NewTagsRepository(db)
+	appTagsService := tagsService.NewService(appTagsRepository, logger)
+	appTagsPolicy := tagsPolicy.NewPolicy(appTagsService)
+	appHandlerTags := tags.NewHandler(appTagsPolicy)
+	appHandlerTags.Register(appTagsRouter)
+
 	// Пользователи
 	appUsersRedisStorage := redisStorage.NewRedisStorage(redisClient)
 	appUsersTelegramManager := telegram.NewTelegramManager(cfg.Telegram.Token)
@@ -133,6 +141,7 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 		appBenchesService,
 		appUsersService,
 		appNotificationsService,
+		appTagsService,
 		geoCoder,
 		logger,
 	)
@@ -146,14 +155,6 @@ func NewApp(cfg *config.Config, logger *zap.Logger) (*App, error) {
 	appBotPolicy := botPolicy.NewPolicy(appBotService)
 	appBotHandler := bot.NewHandler(appBotPolicy)
 	appBotHandler.Register(appBotRouter)
-
-	// Теги
-	appTagsRouter := router.PathPrefix("/api/v1/tags").Subrouter()
-	appTagsRepository := tagsRepository.NewTagsRepository(db)
-	appTagsService := tagsService.NewService(appTagsRepository, logger)
-	appTagsPolicy := tagsPolicy.NewPolicy(appTagsService)
-	appHandlerTags := tags.NewHandler(appTagsPolicy)
-	appHandlerTags.Register(appTagsRouter)
 
 	// Комментарии
 	appCommentsRouter := router.PathPrefix("/api/v1/comments").Subrouter()

--- a/internal/domain/tags.go
+++ b/internal/domain/tags.go
@@ -4,3 +4,8 @@ type Tag struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 }
+
+type TagBench struct {
+	TagID   string `json:"tag_id,omitempty"`
+	BenchID string `json:"bench_id,omitempty"`
+}

--- a/internal/policy/benches/policy.go
+++ b/internal/policy/benches/policy.go
@@ -48,7 +48,9 @@ func (policy *Policy) CreateBenchViaTelegram(ctx context.Context, userTelegramID
 	}
 
 	// Устанавливаем улицу
-	bench.Street = address.Street
+	if address.Street != "" {
+		bench.Street = address.Street
+	}
 
 	// Сохраняем все фотографии, которые нам пришли в виде байт, в Minio
 	images, err := policy.benchesService.SaveImages(ctx, byteImages)
@@ -109,7 +111,9 @@ func (policy *Policy) CreateBench(ctx context.Context, ownerID string, byteImage
 	}
 
 	// Устанавливаем улицу
-	bench.Street = address.Street
+	if address.Street != "" {
+		bench.Street = address.Street
+	}
 
 	bench.Images = images
 	bench.Owner = ownerID

--- a/internal/repository/postgres/benches/model.go
+++ b/internal/repository/postgres/benches/model.go
@@ -10,7 +10,7 @@ type benchModel struct {
 	ID       string         `mapstructure:"id,omitempty"`
 	Lat      float64        `mapstructure:"lat,omitempty"`
 	Lng      float64        `mapstructure:"lng,omitempty"`
-	Street   sql.NullString `mapstructure:"street,omitempty"`
+	Street   sql.NullString `mapstructure:"street,omitempty,squash"`
 	Images   []string       `mapstructure:"images,omitempty"`
 	IsActive bool           `mapstructure:"is_active,omitempty"`
 	OwnerID  string         `mapstructure:"owner_id,omitempty"`
@@ -23,7 +23,12 @@ func (b *benchModel) FromDomain(bench domain.Bench) {
 	b.Images = bench.Images
 	b.IsActive = bench.IsActive
 	b.OwnerID = bench.Owner
-	b.Street = sql.NullString{String: bench.Street, Valid: true}
+
+	if bench.Street != "" {
+		b.Street = sql.NullString{String: bench.Street, Valid: true}
+	} else {
+		b.Street = sql.NullString{String: "", Valid: false}
+	}
 }
 
 func benchModelToDomain(model benchModel) domain.Bench {
@@ -59,10 +64,29 @@ func benchModelsToDomain(models []benchModel) []*domain.Bench {
 
 func (b *benchModel) ToMap() (map[string]interface{}, error) {
 	var updateBenchMap map[string]interface{}
-	err := mapstructure.Decode(b, &updateBenchMap)
+
+	configMapstructure := &mapstructure.DecoderConfig{
+		Result: &updateBenchMap,
+	}
+
+	decoder, errCreateDecoder := mapstructure.NewDecoder(configMapstructure)
+	if errCreateDecoder != nil {
+		return nil, errCreateDecoder
+	}
+
+	err := decoder.Decode(b)
 	if err != nil {
 		return updateBenchMap, err
 	}
+
+	// TODO: зарефакторить, чтобы Mapstructure сам преобразовывал sql.NullString к string или nil
+	if updateBenchMap["Valid"] == true {
+		updateBenchMap["street"] = updateBenchMap["String"]
+	} else {
+		updateBenchMap["street"] = nil
+	}
+	delete(updateBenchMap, "String")
+	delete(updateBenchMap, "Valid")
 
 	return updateBenchMap, nil
 }

--- a/internal/repository/postgres/tags/model.go
+++ b/internal/repository/postgres/tags/model.go
@@ -10,9 +10,30 @@ type tagModel struct {
 	Title string `mapstructure:"title,omitempty"`
 }
 
+type tagBenchModel struct {
+	BenchID string `mapstructure:"bench_id"`
+	TagID   string `mapstructure:"tag_id"`
+}
+
 func (tag *tagModel) FromDomain(tagDomain domain.Tag) {
 	tag.ID = tagDomain.ID
 	tag.Title = tagDomain.Title
+}
+
+func (tagBench *tagBenchModel) FromDomain(tagBenchDomain domain.TagBench) {
+	tagBench.TagID = tagBenchDomain.TagID
+	tagBench.BenchID = tagBenchDomain.BenchID
+
+}
+
+func (tagBench *tagBenchModel) ToMap() (map[string]interface{}, error) {
+	var tagBenchMap map[string]interface{}
+	err := mapstructure.Decode(tagBench, &tagBenchMap)
+	if err != nil {
+		return tagBenchMap, err
+	}
+
+	return tagBenchMap, nil
 }
 
 func tagModelToDomain(model tagModel) domain.Tag {

--- a/internal/service/benches/service.go
+++ b/internal/service/benches/service.go
@@ -19,7 +19,7 @@ import (
 type Service interface {
 	GetListBenches(ctx context.Context, isActive bool, sortOptions *sort.Options,
 		paginateOptions *paginate.Options) ([]*domain.Bench, error)
-	CreateBench(ctx context.Context, bench domain.Bench) error
+	CreateBench(ctx context.Context, bench domain.Bench) (*domain.Bench, error)
 	DecisionBench(ctx context.Context, benchID string, decision bool) error
 	GetBenchByID(ctx context.Context, id string) (*domain.Bench, error)
 	SaveImages(ctx context.Context, images [][]byte) ([]string, error)
@@ -81,13 +81,13 @@ func (service *service) CountAllBenches(ctx context.Context, isActive bool) (int
 	return count, nil
 }
 
-func (service *service) CreateBench(ctx context.Context, bench domain.Bench) error {
-	err := service.db.Create(ctx, bench)
+func (service *service) CreateBench(ctx context.Context, bench domain.Bench) (*domain.Bench, error) {
+	resultBench, err := service.db.Create(ctx, bench)
 	if err != nil {
 		service.log.Error("failed create bench", zap.Error(err))
-		return apperror.ErrFailedToCreate
+		return nil, apperror.ErrFailedToCreate
 	}
-	return nil
+	return resultBench, nil
 }
 
 func (service *service) UpdateBench(ctx context.Context, id string, bench domain.Bench) error {

--- a/internal/service/tags/service.go
+++ b/internal/service/tags/service.go
@@ -10,6 +10,7 @@ import (
 type Service interface {
 	GetAllTags(ctx context.Context) ([]*domain.Tag, error)
 	CreateTag(ctx context.Context, tag domain.Tag) error
+	AddTagToBench(ctx context.Context, tagBench domain.TagBench) error
 }
 
 type service struct {
@@ -37,4 +38,8 @@ func (service *service) CreateTag(ctx context.Context, tag domain.Tag) error {
 		return err
 	}
 	return nil
+}
+
+func (service *service) AddTagToBench(ctx context.Context, tagBench domain.TagBench) error {
+	return service.db.CreateTagToBench(ctx, tagBench)
 }

--- a/internal/service/users/service.go
+++ b/internal/service/users/service.go
@@ -45,10 +45,12 @@ func (service *service) LoginViaTelegram(ctx context.Context, telegramUser domai
 		var errCreate error
 		dbUser, errCreate = service.db.Create(ctx, user)
 		if errCreate != nil {
+			service.log.Error("error create user in database", zap.Error(errCreate))
 			return "", "", errCreate
 		}
 	} else {
 		if err != nil {
+			service.log.Error("error check exception", zap.Error(err))
 			return "", "", err
 		}
 	}
@@ -69,17 +71,20 @@ func (service *service) LoginViaTelegram(ctx context.Context, telegramUser domai
 	var token string
 	token, err = service.tokenManager.NewJWT(dbUser.ID, dbUser.Role, 60*time.Minute)
 	if err != nil {
+		service.log.Error("error generate new access token", zap.Error(err))
 		return "", "", err
 	}
 
 	var refreshToken string
 	refreshToken, err = service.tokenManager.NewRefreshToken()
 	if err != nil {
+		service.log.Error("error generate new refresh token", zap.Error(err))
 		return "", "", err
 	}
 
 	err = service.redisStorage.WriteRefreshToken(ctx, refreshToken, dbUser.ID, 60*time.Minute)
 	if err != nil {
+		service.log.Error("error write refresh token to redis", zap.Error(err))
 		return "", "", err
 	}
 

--- a/internal/transport/httpv1/benches/benches.go
+++ b/internal/transport/httpv1/benches/benches.go
@@ -211,10 +211,11 @@ func (handler *Handler) createBench(writer http.ResponseWriter, request *http.Re
 	}
 
 	// Создаём лавочку
-	errCreate := handler.policy.CreateBench(
+	_, errCreate := handler.policy.CreateBench(
 		request.Context(),
 		request.Context().Value("userID").(string),
 		bench.Images,
+		request.Form["tags"],
 		bench.ToDomain(),
 	)
 	if errCreate != nil {


### PR DESCRIPTION
Исправлен баг, при котором лавочка не создавалась из-за пустой улицы. 

В `benchesPolicy.Create` была добавлена поддержка тегов. Теперь теги можно привязывать сразу с лавочкой. 
При запросе на `/api/v1/benches [post]` - теперь можно передать поле `tags`, которое будет список ID. 

- [x] Добавить возможность прикреплять теги во время создания лавочки
- [ ] Добавить возможность изменять теги во время обновления лавочки

Close #204 