### PR TITLE
Исправлена ошибка с получением адреса при создании лавочки

### DIFF
--- a/internal/policy/benches/policy.go
+++ b/internal/policy/benches/policy.go
@@ -115,7 +115,7 @@ func (policy *Policy) CreateBench(ctx context.Context, ownerID string, byteImage
 	}
 
 	// Устанавливаем улицу
-	if address.Street != "" {
+	if address != nil && address.Street != "" {
 		bench.Street = address.Street
 	}
 


### PR DESCRIPTION
Теперь, если указаны случайные координаты, то в базе данных будет `nil`.   