### PR TITLE
Исправлен swagger

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -199,7 +199,7 @@ const docTemplate = `{
             }
         },
         "/api/v1/benches/nearest/{id}": {
-            "delete": {
+            "get": {
                 "description": "Get the nearest benches by bench",
                 "tags": [
                     "Benches"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -187,7 +187,7 @@
             }
         },
         "/api/v1/benches/nearest/{id}": {
-            "delete": {
+            "get": {
                 "description": "Get the nearest benches by bench",
                 "tags": [
                     "Benches"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -404,7 +404,7 @@ paths:
       tags:
       - Benches
   /api/v1/benches/nearest/{id}:
-    delete:
+    get:
       description: Get the nearest benches by bench
       parameters:
       - description: Bench ID

--- a/internal/transport/httpv1/benches/benches.go
+++ b/internal/transport/httpv1/benches/benches.go
@@ -348,7 +348,7 @@ func (handler *Handler) decisionBench(writer http.ResponseWriter, request *http.
 // @Success 200
 // @Failure 400 {object} apperror.AppError
 // @Failure 418
-// @Router /api/v1/benches/nearest/{id} [delete]
+// @Router /api/v1/benches/nearest/{id} [get]
 func (handler *Handler) nearestBenches(writer http.ResponseWriter, request *http.Request) error {
 	idBench := mux.Vars(request)["id"]
 


### PR DESCRIPTION
Обновлена информация в swagger'e для endpoint'a - `/api/v1/benches/nearest/{id}`. 

Исправлен метод с `DELETE` на `GET`. 